### PR TITLE
Sort users by username, always keep options in same order

### DIFF
--- a/event/viewtopic.php
+++ b/event/viewtopic.php
@@ -285,7 +285,13 @@ class viewtopic implements EventSubscriberInterface
 			}
 
 		}
-		foreach ($this->hookup->hookup_users as $hookup_user)
+		$sorted_hookup_users = array();
+		foreach ($this->hookup->hookup_users as $user_id => $hookup_user)
+		{
+			$sorted_hookup_users[$user_details[$user_id]['username']] = $hookup_user;
+		}
+		ksort($sorted_hookup_users);
+		foreach ($sorted_hookup_users as $hookup_user)
 		{
 			$is_self = ($hookup_user['user_id'] == $this->user->data['user_id']);
 

--- a/functions/hookup.php
+++ b/functions/hookup.php
@@ -93,7 +93,7 @@ class hookup
 		$sql = 'SELECT date_id, date_time, text
 				FROM ' . $this->hookup_dates_table . '
 				WHERE topic_id=' . (int) $topic_id . '
-				ORDER BY date_time ASC';
+				ORDER BY date_time ASC, date_id';
 		$result = $db->sql_query($sql);
 		//associative array date_id => date_row
 		$this->hookup_dates = array();


### PR DESCRIPTION
Currently, when using the "text-choice" Feature, the options may be ordered differently after refreshing the thread. The same holds for the ordering of the users in the table.

This PR introduces two small changes that fix that. Users will always be ordered alphabetically and the text-choice options will be sorted in the same order they were entered in the hookup.
